### PR TITLE
Fix a bug of getting sonokai root dir on Windows

### DIFF
--- a/autoload/sonokai.vim
+++ b/autoload/sonokai.vim
@@ -222,7 +222,7 @@ endfunction "}}}
 function! sonokai#ft_rootpath(path) "{{{
   " Get the directory where `after/ftplugin` is generated.
   if (matchstr(a:path, '^/usr/share') ==# '') || has('win32') " Return the plugin directory. The `after/ftplugin` directory should never be generated in `/usr/share`, even if you are a root user.
-    return substitute(a:path, '/colors/sonokai\.vim$', '', '')
+    return fnamemodify(a:path, ':p:h:h')
   else " Use vim home directory.
     if has('nvim')
       return stdpath('config')


### PR DESCRIPTION
This issue is the same as sainnhe/edge#20.