### PR TITLE
Set alacritty themes' bright black to grey from their vim palettes  

### DIFF
--- a/alacritty/README.md
+++ b/alacritty/README.md
@@ -50,7 +50,7 @@ colors:
     white: "0xe3e1e4"
 
   bright:
-	black: "0x848089"
+    black: "0x848089"
     red: "0xf85e84"
     green: "0x9ecd6f"
     yellow: "0xe5c463"


### PR DESCRIPTION
### Issue

The black and bright black on the alacritty colorschemes are identical, leading to poor readability in applications where bright black is used to color text.

![Screenshot from 2021-10-12 23-07-25](https://user-images.githubusercontent.com/63527622/137060462-d0ef4b65-5fa3-4e1f-bc83-995db32831c8.png)

### Proposed Fix

Set the bright black on the alacritty colorschemes to the grey from the vim colorschemes.


![Screenshot from 2021-10-12 23-08-24](https://user-images.githubusercontent.com/63527622/137060471-debb0aa5-7918-4723-ac77-11ce0ca4ff5c.png)

