### PR TITLE
Changed andromeda bg_green

### DIFF
--- a/autoload/sonokai.vim
+++ b/autoload/sonokai.vim
@@ -92,7 +92,7 @@ function! sonokai#get_palette(style) "{{{
           \ 'bg4':        ['#3f445b',   '237'],
           \ 'bg_red':     ['#ff6188',   '203'],
           \ 'diff_red':   ['#55393d',   '52'],
-          \ 'bg_green':   ['#a9dc76',   '107'],
+          \ 'bg_green':   ['#87b05d',   '107'],
           \ 'diff_green': ['#394634',   '22'],
           \ 'bg_blue':    ['#77d5f0',   '110'],
           \ 'diff_blue':  ['#354157',   '17'],


### PR DESCRIPTION
When searching for a text, the cursor could hardly be distinguished from the background

Original
![sonokai_original_search](https://user-images.githubusercontent.com/5247907/137520713-8f0766ad-fd9f-49a1-86f4-fae158def672.png)

New
![sonokai_search_new](https://user-images.githubusercontent.com/5247907/137520744-d59711a4-2f27-47bd-a420-7190d7efa3f2.png)

