### PR TITLE
Add bright black color to terminal colors

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -305,14 +305,15 @@ endif
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   " Definition
   let s:terminal = {
-        \ 'black':    s:palette.black,
-        \ 'red':      s:palette.red,
-        \ 'yellow':   s:palette.yellow,
-        \ 'green':    s:palette.green,
-        \ 'cyan':     s:palette.orange,
-        \ 'blue':     s:palette.blue,
-        \ 'purple':   s:palette.purple,
-        \ 'white':    s:palette.fg
+        \ 'black':           s:palette.black,
+        \ 'red':             s:palette.red,
+        \ 'yellow':          s:palette.yellow,
+        \ 'green':           s:palette.green,
+        \ 'cyan':            s:palette.orange,
+        \ 'blue':            s:palette.blue,
+        \ 'purple':          s:palette.purple,
+        \ 'white':           s:palette.fg,
+        \ 'bright_black':    s:palette.grey,
         \ }
   " Implementation: {{{
   if !has('nvim')
@@ -328,7 +329,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     let g:terminal_color_5 = s:terminal.purple[0]
     let g:terminal_color_6 = s:terminal.cyan[0]
     let g:terminal_color_7 = s:terminal.white[0]
-    let g:terminal_color_8 = s:terminal.black[0]
+    let g:terminal_color_8 = s:terminal.bright_black[0]
     let g:terminal_color_9 = s:terminal.red[0]
     let g:terminal_color_10 = s:terminal.green[0]
     let g:terminal_color_11 = s:terminal.yellow[0]


### PR DESCRIPTION
This sets the bright black terminal color to be the gray color of the
palette. This makes terminal programs like fzf + bat render colors
similarly to how they would be rendered in the terminal using sonokai
colors.

## bat + Alacritty colors
<img width="548" alt="Screen Shot 2021-12-30 at 4 01 25 PM" src="https://user-images.githubusercontent.com/342554/147787713-fa5de404-dd89-47a5-a590-a409f842fc68.png">

## vim + bat + fzf on master

<img width="327" alt="Screen Shot 2021-12-30 at 4 02 17 PM" src="https://user-images.githubusercontent.com/342554/147787752-6fd029fa-97a0-49a8-90da-31889b911267.png">

## vim + bat + fzf on this branch
<img width="487" alt="Screen Shot 2021-12-30 at 4 02 50 PM" src="https://user-images.githubusercontent.com/342554/147787789-6ba72455-aa19-4aee-92f6-61417439ff97.png">

