### PR TITLE
fix(lualine): wasn't respecting transparency

### DIFF
--- a/lua/lualine/themes/sonokai.lua
+++ b/lua/lualine/themes/sonokai.lua
@@ -9,40 +9,45 @@
 local configuration = vim.fn['sonokai#get_configuration']()
 local palette = vim.fn['sonokai#get_palette'](configuration.style)
 
+local c_background = palette.bg1[1]
+if vim.g.sonokai_transparent_background == 1 then
+  c_background = palette.none[1]
+end
+
 return {
   normal = {
     a = {bg = palette.bg_blue[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg4[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   insert = {
     a = {bg = palette.bg_green[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg4[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   visual = {
     a = {bg = palette.bg_red[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg4[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   replace = {
     a = {bg = palette.orange[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg4[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   command = {
     a = {bg = palette.yellow[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg4[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   terminal = {
     a = {bg = palette.purple[1], fg = palette.bg0[1], gui = 'bold'},
     b = {bg = palette.bg3[1], fg = palette.fg[1]},
-    c = {bg = palette.bg1[1], fg = palette.fg[1]}
+    c = {bg = c_background, fg = palette.fg[1]}
   },
   inactive = {
-    a = {bg = palette.bg1[1], fg = palette.grey[1]},
-    b = {bg = palette.bg1[1], fg = palette.grey[1]},
-    c = {bg = palette.bg1[1], fg = palette.grey[1]}
+    a = {bg = c_background, fg = palette.grey[1]},
+    b = {bg = c_background, fg = palette.grey[1]},
+    c = {bg = c_background, fg = palette.grey[1]}
   }
 }


### PR DESCRIPTION
Hi! Love the colorscheme
I recently started using `vim.g.sonokai_transparent_background=1`, and noticed that the statusline wasn't respecting that setting, which looks weird