### PR TITLE
Fix transparent background not working

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -28,7 +28,7 @@ endif
 " }}}
 " Common Highlight Groups: {{{
 " UI: {{{
-if s:configuration.transparent_background == 1
+if s:configuration.transparent_background >= 1
   call sonokai#highlight('Normal', s:palette.fg, s:palette.none)
   call sonokai#highlight('Terminal', s:palette.fg, s:palette.none)
   if s:configuration.show_eob


### PR DESCRIPTION
In Neovim in Konsole, let g:sonokai_transparent_background = 2 not work at all, nothing is transparent with this config.
(however, make it "= 1" works)
So, I figured out the solution, with a single change on "=" here:

if s:configuration.transparent_background == 1
to
if s:configuration.transparent_background >= 1

This one will make all the 3 values (=0, 1, 2) work, tested well on my terminal (Konsole).