### PR TITLE
fix(nvim-cmp): make CmpItemAbbr and CmpItemAbbrDeprecated distinguishable

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -830,7 +830,7 @@ if has('nvim')
 call sonokai#highlight('CmpItemAbbrMatch', s:palette.green, s:palette.none, 'bold')
 call sonokai#highlight('CmpItemAbbrMatchFuzzy', s:palette.green, s:palette.none, 'bold')
 highlight! link CmpItemAbbr Fg
-highlight! link CmpItemAbbrDeprecated Fg
+highlight! link CmpItemAbbrDeprecated Grey
 highlight! link CmpItemMenu Fg
 highlight! link CmpItemKind Blue
 highlight! link CmpItemKindText Fg


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/62944333/187590182-ce58d5ca-dc16-4c41-b040-a94b4838a9e7.png)

After:

![after](https://user-images.githubusercontent.com/62944333/187590412-7abd05c4-2ca6-487c-8cab-e0ae3c824247.png)
