### PR TITLE
fix(indent-blankline): Set a highlighted indent character color

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -942,7 +942,8 @@ highlight! link HopUnmatched Grey
 highlight! link IndentBlanklineChar Conceal
 highlight! link IndentBlanklineSpaceChar Conceal
 highlight! link IndentBlanklineSpaceCharBlankline Conceal
-highlight! link IndentBlanklineContextChar Grey
+highlight! link IndentBlanklineContextChar Red
+highlight! link IndentBlanklineContextSpaceChar Conceal
 " }}}
 " p00f/nvim-ts-rainbow {{{
 highlight! link rainbowcol1 Red


### PR DESCRIPTION
When using  _**indent-blankline.nvim**_ plugin, the context indent character wasn't being highlighted. This sets a default highlighting color.

Before:
![Screenshot 2022-10-24 at 00 25 36](https://user-images.githubusercontent.com/5073663/197423229-a1df58e5-4e25-41d6-8d38-2f4432db23e8.png)
fore:

After:
![Screenshot 2022-10-24 at 00 24 35](https://user-images.githubusercontent.com/5073663/197423224-1d4d50c8-7a59-40ec-b27b-8c15acc2508d.png)
