### PR TITLE
fix(nix): add `filewritable` check to `syn_rootpath`

### DIFF
--- a/autoload/sonokai.vim
+++ b/autoload/sonokai.vim
@@ -267,9 +267,10 @@ function! sonokai#syn_write(rootpath, syn, content) "{{{
   call writefile(['" vim: set sw=2 ts=2 sts=2 et tw=80 ft=vim fdm=marker fmr={{{,}}}:'], syn_path, 'a')
 endfunction "}}}
 function! sonokai#syn_rootpath(path) "{{{
+  let plugin_path = fnamemodify(a:path, ':p:h:h')
   " Get the directory where `after/syntax` is generated.
-  if (matchstr(a:path, '^/usr/share') ==# '') " Return the plugin directory. The `after/syntax` directory should never be generated in `/usr/share`, even if you are a root user.
-    return fnamemodify(a:path, ':p:h:h')
+  if (matchstr(a:path, '^/usr/share') ==# '' && filewritable(plugin_path) == 2) " Return the plugin directory. The `after/syntax` directory should never be generated in `/usr/share`, even if you are a root user.
+    return plugin_path
   else " Use vim home directory.
     if has('nvim')
       return stdpath('config')

--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -10,7 +10,7 @@
 let s:configuration = sonokai#get_configuration()
 let s:palette = sonokai#get_palette(s:configuration.style, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Mon Sep 30 10:09:56 UTC 2024'
+let s:last_modified = 'Wed Dec 25 11:24:30 PM UTC 2024'
 let g:sonokai_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'sonokai' && s:configuration.better_performance)


### PR DESCRIPTION
Added a test to `syn_rootpath(path)` to check if the directory it wants to write to is in fact writable (and a directory).

This fixes an issue using nix where the plugin is stored into `/nix/store/...` which happens to be readonly.

I could have just added a test that it isn't in `/nix/store` as the same as `^/usr/share` but this seems like its more robust.

I tested it out on NixOS and Arch with a plugin dir of `~/.local/share/nvim/plugged/sonokai/` and both work. 