### PR TITLE
feat(blink): improve blink.cmp highlights that default to NonText

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -1118,6 +1118,9 @@ endfor
 " }}}
 " Saghen/blink.cmp {{{
 call sonokai#highlight('BlinkCmpLabelMatch', s:palette.green, s:palette.none, 'bold')
+highlight! link BlinkCmpGhostText Grey
+highlight! link BlinkCmpSource Grey
+highlight! link BlinkCmpLabelDeprecated Grey
 highlight! link BlinkCmpKind Blue
 for kind in g:sonokai_lsp_kind_color
   execute "highlight! link BlinkCmpKind" . kind[0] . " " . kind[1]


### PR DESCRIPTION
NonText defaults to color bg4, which is almost indistinguishable from default / float background. This makes ghost text and other components (e.g., item source or deprecated label) very difficult to read. These highlight groups should instead be linked to grey (same as the Comment group, which is also the default used by `nvim-cmp` for ghost text and deprecated label).

Before:
![blink-before](https://github.com/user-attachments/assets/7cef1dcf-32bd-433b-aeca-163db98dfde2)

After:
![blink-after](https://github.com/user-attachments/assets/eaef94ee-c4b9-4a3f-81fc-11de32049e97)
