### PR TITLE
feat(fzf-lua): Make nvim fzf-lua borders and title flags match fzf.vim

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -1159,6 +1159,11 @@ highlight! link TelescopeBorder Grey
 highlight! link TelescopePromptPrefix Blue
 highlight! link TelescopeSelection DiffAdd
 " }}}
+" ibhagwan/fzf-lua {{{
+highlight! link FzfLuaBorder Grey
+highlight! link FzfLuaTitle Title
+highlight! link FzfLuaTitleFlags Yellow
+" }}}
 " folke/snacks.nvim {{{
 highlight! link SnacksDashboardDesc Yellow
 highlight! link SnacksDashboardDir Gray 


### PR DESCRIPTION
The `fzf.vim` color scheme uses grey for borders and yellow for info (e.g., spinner, item count, etc.). The nvim `fzf-lua` plugin generates correct `g:fzf_colors`, but has additional highlight groups that don't match.

In particular, the borders should be grey, and title flags (e.g., options whether symlinks are followed or hidden files are ignored) should match info color (yellow).

Reference `fzf.vim`:
![fzf vim](https://github.com/user-attachments/assets/fb8c9f8a-0916-4a14-8944-642a4bdaf587)

`fzf-lua` before:
![fzf-lua-before](https://github.com/user-attachments/assets/2c2bced3-838f-4a84-96bf-3afad95bea62)

`fzf-lua` after:
![fzf-lua-after](https://github.com/user-attachments/assets/5fb8383b-e3df-4a70-ae1f-4cfcffeb1525)