### PR TITLE
feat(blink): link to Grey new blink.cmp highlights that default to No…

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -1139,6 +1139,8 @@ endfor
 call sonokai#highlight('BlinkCmpLabelMatch', s:palette.green, s:palette.none, 'bold')
 highlight! link BlinkCmpGhostText Grey
 highlight! link BlinkCmpSource Grey
+highlight! link BlinkCmpLabelDetail Grey
+highlight! link BlinkCmpLabelDescription Grey
 highlight! link BlinkCmpLabelDeprecated Grey
 highlight! link BlinkCmpKind Blue
 for kind in g:sonokai_lsp_kind_color


### PR DESCRIPTION
See rationale in https://github.com/sainnhe/sonokai/pull/111. See new highlights in
https://cmp.saghen.dev/configuration/appearance.html#highlight-groups.