### PR TITLE
feat(blink): remove redundant `blink.cmp` highlights

### DIFF
--- a/colors/sonokai.vim
+++ b/colors/sonokai.vim
@@ -1138,10 +1138,6 @@ endfor
 " Saghen/blink.cmp {{{
 call sonokai#highlight('BlinkCmpLabelMatch', s:palette.green, s:palette.none, 'bold')
 highlight! link BlinkCmpGhostText Grey
-highlight! link BlinkCmpSource Grey
-highlight! link BlinkCmpLabelDetail Grey
-highlight! link BlinkCmpLabelDescription Grey
-highlight! link BlinkCmpLabelDeprecated Grey
 highlight! link BlinkCmpKind Blue
 for kind in g:sonokai_lsp_kind_color
   execute "highlight! link BlinkCmpKind" . kind[0] . " " . kind[1]


### PR DESCRIPTION
The `NonText` highlight groups recently changed to `PmenuExtra`, which in Sonokai defaults to `Grey`. Therefore, the overrides are now redundant.

See [here](https://github.com/Saghen/blink.cmp/commit/3a977226433e0c3bbc15d3c9ca2e7ef589b115af) and [here](https://github.com/Saghen/blink.cmp/pull/1284#event-16391099634).